### PR TITLE
Update cis_6.1.x.yml

### DIFF
--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -230,7 +230,7 @@
             warn_control_id: '6.1.11'
         when: rhel_09_6_1_11_ungrouped_files_found
   vars:
-      - rhel_09_6_1_11_ungrouped_files_found: false
+      rhel_09_6_1_11_ungrouped_files_found: false
   when:
       - rhel9cis_rule_6_1_11
   tags:


### PR DESCRIPTION
Fixed [DEPRECATION WARNING]: Specifying a list of dictionaries for vars is deprecated in favor of specifying a dictionary. This feature will be removed in version 2.18.